### PR TITLE
Add sponsors to homepage

### DIFF
--- a/assets/stylesheets/components/_navigation-top.scss
+++ b/assets/stylesheets/components/_navigation-top.scss
@@ -2,9 +2,9 @@
   background: url('assets/images/ribbon.png') repeat-x;
   min-height: 61px;
   position: relative;
-  margin: 0 #{-$size_site-gutter/2} 120px;
+  margin: 0 #{-$size__site-gutter/2} 120px;
   width: 100%;
-  width: calc(100% + #{$size_site-gutter});
+  width: calc(100% + #{$size__site-gutter});
   z-index: 5;
 
 	ul {

--- a/assets/stylesheets/components/_sponsors.scss
+++ b/assets/stylesheets/components/_sponsors.scss
@@ -3,7 +3,7 @@
 	display: flex;
 	justify-content: space-between;
 	margin: 0 auto;
-	max-width: $size_site-width;
+	max-width: $size__site-width;
 
 	.sponsor {
 		margin: 10px;

--- a/assets/stylesheets/components/_sponsors.scss
+++ b/assets/stylesheets/components/_sponsors.scss
@@ -1,0 +1,11 @@
+.justonetree-sponsor-logos {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	margin: 0 auto;
+	max-width: $size_site-width;
+
+	.sponsor {
+		margin: 10px;
+	}
+}

--- a/assets/stylesheets/layout/_colophon.scss
+++ b/assets/stylesheets/layout/_colophon.scss
@@ -2,7 +2,7 @@
   background: $color__text;
   color: $color__white;
   @include font-size(0.9);
-  padding: $size_site-gutter 0;
+  padding: $size__site-gutter 0;
   text-align: center;
 
   a {

--- a/assets/stylesheets/layout/_content-sidebar.scss
+++ b/assets/stylesheets/layout/_content-sidebar.scss
@@ -1,27 +1,27 @@
 .site {
-	padding: $size_site-gutter/2;
+	padding: $size__site-gutter/2;
 	margin: 0 auto;
 }
 
 @include tablet {
 	.site-content {
 		margin: 0 auto;
-		max-width: $size_site-width;
+		max-width: $size__site-width;
 	}
 
 	.site-content .content-area {
 		display: inline-block;
-		padding-right: $size_site-gutter;
+		padding-right: $size__site-gutter;
 		vertical-align: top;
-		width: $size_site-main - $size_site-sidebar;
+		width: $size__site-main - $size__site-sidebar;
 	}
 
 	.site-content .widget-area {
 		display: inline-block;
 		margin-left: -5px;
-		padding-left: $size_site-gutter;
+		padding-left: $size__site-gutter;
 		vertical-align: top;
-		width: $size_site-sidebar;
+		width: $size__site-sidebar;
 	}
 }
 
@@ -31,6 +31,6 @@
 
 	div {
 		margin: 0 auto;
-		max-width: $size_site-width;
+		max-width: $size__site-width;
 	}
 }

--- a/assets/stylesheets/layout/_front-page.scss
+++ b/assets/stylesheets/layout/_front-page.scss
@@ -2,12 +2,12 @@
 	background: $color__primary;
 	border-bottom: 8px solid $color__primary;
 	line-height: 1;
-	margin: -150px -$size_site-gutter/2 0 -$size_site-gutter/2;
+	margin: -150px -$size__site-gutter/2 0 -$size__site-gutter/2;
 	position: relative;
 	text-align: center;
 	transform: skewY(-1deg);
 	width: 100%;
-	width: calc(100% + #{$size_site-gutter});
+	width: calc(100% + #{$size__site-gutter});
 	z-index: 1;
 }
 
@@ -42,7 +42,7 @@
 
 .action-widget {
 	margin-right: -4px;
-	padding: $size_site-gutter/2;
+	padding: $size__site-gutter/2;
 	vertical-align: top;
 	width: 100%;
 

--- a/assets/stylesheets/layout/_layout.scss
+++ b/assets/stylesheets/layout/_layout.scss
@@ -34,7 +34,7 @@ body {
 .no-sidebar .content-area {
 	padding-right: 0;
 	margin: 0 auto;
-	max-width: $size_site-width;
+	max-width: $size__site-width;
 	text-align: left;
 	width: auto;
 }

--- a/assets/stylesheets/layout/_layout.scss
+++ b/assets/stylesheets/layout/_layout.scss
@@ -20,6 +20,7 @@ body {
 @import "masthead";
 @import "content-sidebar";
 @import "colophon";
+@import "../components/sponsors";
 
 /*--------------------------------------------------------------
 ## Single Column / No Active Sidebar

--- a/assets/stylesheets/layout/_posts.scss
+++ b/assets/stylesheets/layout/_posts.scss
@@ -24,11 +24,11 @@
 		color: $color__tertiary;
 		font-weight: 500;
 		font-size: 0.9rem;
-		padding-bottom: $size_site-gutter/4;
+		padding-bottom: $size__site-gutter/4;
 		text-decoration: none;
   }
 }
 
 .entry-title {
-  margin-top: $size-site-gutter/2;
+  margin-top: $size__site-gutter/2;
 }

--- a/assets/stylesheets/sections/_widgets.scss
+++ b/assets/stylesheets/sections/_widgets.scss
@@ -10,7 +10,7 @@
 /* Lists in widgets (pages, categories, comments, etc) */
 .widget ul {
 		list-style-type: none;
-		margin: -$size_site-gutter/2 0 0 0;
+		margin: -$size__site-gutter/2 0 0 0;
 		padding: 0;
 
 		li {

--- a/assets/stylesheets/variables/_structure.scss
+++ b/assets/stylesheets/variables/_structure.scss
@@ -1,5 +1,5 @@
-$size_site-main: 100%;
-$size_site-sidebar: 33%;
+$size__site-main: 100%;
+$size__site-sidebar: 33%;
 
-$size_site-gutter: 20px;
-$size_site-width: 1040px;
+$size__site-gutter: 20px;
+$size__site-width: 1040px;

--- a/components/footer/sponsors.php
+++ b/components/footer/sponsors.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Template part for outputting a list of sponsors.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package Just_One_Tree
+ */
+?>
+
+<section class="justonetree-sponsor-logos">
+	<?php // Query posts for our sponsors.
+	$args = array(
+		'post_type' => 'sponsor',
+
+	);
+	$the_query = new WP_Query( $args );
+
+	// Loop through all sponsors and show them in a list.
+	if ( $the_query->have_posts() ) :
+		while ( $the_query->have_posts() ) :
+			$the_query->the_post();
+			get_template_part( 'components/sponsor/content-list' );
+		endwhile;
+		wp_reset_postdata();
+	endif;
+	?>
+</section>

--- a/components/sponsor/content-list.php
+++ b/components/sponsor/content-list.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Template part for displaying sponsors in a list.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package Just_One_Tree
+ */
+?>
+
+<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<?php if ( has_post_thumbnail() ) : ?>
+		<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
+			<?php the_post_thumbnail(); ?>
+		</a>
+	<?php endif; ?>
+
+</div><!-- #post-## -->

--- a/footer.php
+++ b/footer.php
@@ -14,14 +14,13 @@
 </div><!-- #page -->
 
 <footer id="colophon" class="site-footer" role="contentinfo">
-	<?php get_template_part( 'components/footer/sponsors' ); ?>
-
 	<?php justonetree_social_menu(); ?>
 	<?php get_template_part( 'components/footer/site', 'info' ); ?>
 	<?php get_template_part( 'components/navigation/navigation', 'footer' ); ?>
 </footer>
 
-<?php wp_footer(); ?>
+<?php get_template_part( 'components/footer/sponsors' ); ?>
 
+<?php wp_footer(); ?>
 </body>
 </html>

--- a/footer.php
+++ b/footer.php
@@ -14,6 +14,8 @@
 </div><!-- #page -->
 
 <footer id="colophon" class="site-footer" role="contentinfo">
+	<?php get_template_part( 'components/footer/sponsors' ); ?>
+
 	<?php justonetree_social_menu(); ?>
 	<?php get_template_part( 'components/footer/site', 'info' ); ?>
 	<?php get_template_part( 'components/navigation/navigation', 'footer' ); ?>

--- a/functions.php
+++ b/functions.php
@@ -194,3 +194,8 @@ require get_template_directory() . '/inc/jetpack.php';
  * Use SVG for icons.
  */
 require get_template_directory() . '/inc/svg-icons.php';
+
+/**
+ * Load custom post type setup.
+ */
+require get_template_directory() . '/inc/cpt/sponsors.php';

--- a/inc/cpt/sponsors.php
+++ b/inc/cpt/sponsors.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Sponsors CPT
+ *
+ * @package Just_One_Tree
+ */
+class JustOneTree_Sponsor {
+	/**
+	 * Singleton holder
+	 */
+	private static $__instance = null;
+
+	/**
+	 * Class variables
+	 */
+	private $cpt = 'sponsor';
+
+	/**
+	 * Instantiate the singleton
+	 */
+	public static function get_instance() {
+		if ( ! is_a( self::$__instance, __CLASS__ ) ) {
+			self::$__instance = new self;
+		}
+		return self::$__instance;
+	}
+
+	/**
+	 * Add those actions to the init hook when the class is instantiated.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_CPT' ) );
+	}
+
+	/**
+	 * Register CPT.
+	 *
+	 * @action init
+	 * @return null
+	 */
+	public function register_CPT() {
+		$cpt = array(
+			'labels'              => array(
+				'name'                => __( 'Sponsors', 'justonetree' ),
+				'singular_name'       => __( 'Sponsor', 'justonetree' ),
+				'add_new'             => _x( 'Add New Sponsor', 'justonetree', 'justonetree' ),
+				'add_new_item'        => __( 'Add New Sponsor', 'justonetree' ),
+				'edit_item'           => __( 'Edit Sponsor', 'justonetree' ),
+				'new_item'            => __( 'New Sponsor', 'justonetree' ),
+				'view_item'           => __( 'View Sponsor', 'justonetree' ),
+				'search_items'        => __( 'Search Sponsors', 'justonetree' ),
+				'not_found'           => __( 'No sponsors found', 'justonetree' ),
+				'not_found_in_trash'  => __( 'No sponsors found in Trash', 'justonetree' ),
+				'parent_item_colon'   => __( 'Sponsor:', 'justonetree' ),
+				'menu_name'           => __( 'Sponsors', 'justonetree' ),
+			),
+			'menu_icon'	      => 'dashicons-awards',
+			'hierarchical'        => false,
+			'public'              => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'show_in_admin_bar'   => true,
+			'show_in_nav_menus'   => true,
+			'publicly_queryable'  => true,
+			'exclude_from_search' => true,
+			'has_archive'         => true,
+			'query_var'           => true,
+			'can_export'          => true,
+			'rewrite'             => array(
+				'with_front'  => false,
+				'slug'        => 'sponsors',
+			),
+			'capability_type'     => 'post',
+			'supports'            => array(
+				'title',
+				'editor',
+				'revisions',
+				'thumbnail',
+			),
+		);
+		register_post_type( $this->cpt, $cpt );
+	}
+}
+JustOneTree_Sponsor::get_instance();

--- a/style.css
+++ b/style.css
@@ -806,6 +806,18 @@ body {
 #footer-menu li {
   display: inline-block; }
 
+.justonetree-sponsor-logos {
+  -ms-flex-align: center;
+  align-items: center;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: 1040px; }
+  .justonetree-sponsor-logos .sponsor {
+    margin: 10px; }
+
 /*--------------------------------------------------------------
 ## Single Column / No Active Sidebar
 --------------------------------------------------------------*/


### PR DESCRIPTION
This sets up a CPT for sponsors, allowing for easy insertion on the homepage.

Note: right now, sponsor logos are linked to a sponsor details page, and all sponsor logos are shown on all pages. We may want to fine-tune this behaviour a smidge.