### PR TITLE
Develop basic initial tree-o-meter.

### DIFF
--- a/assets/stylesheets/components/_treeometer.scss
+++ b/assets/stylesheets/components/_treeometer.scss
@@ -2,6 +2,16 @@ $progressBarColour: $color__highlight;
 $progressValueColour: $color__accent;
 $progressBarRadius: 15px;
 
+.justonetree-treeometer {
+	max-width: 300px;
+}
+
+// Remove default browser styling.
+progress,
+progress[value] {
+	appearance: none;
+}
+
 .progress-bar {
 	background-color: $progressBarColour;
 	border: 2px solid $color__text;
@@ -48,11 +58,10 @@ $progressBarRadius: 15px;
 	height: 0.3em;
 }
 
-
-.justonetree-treeometer dl {
-	margin: -200px 0 0 $progressBarRadius;
-
-	dd {
-		margin-left: 0;
-	}
+// Text
+#justonetree-treeometer-text {
+	font-size: 0.8em;
+	text-align: center;
+	margin: -200px 0 0 10px;
+	max-width: 230px;
 }

--- a/assets/stylesheets/components/_treeometer.scss
+++ b/assets/stylesheets/components/_treeometer.scss
@@ -1,0 +1,58 @@
+$progressBarColour: $color__highlight;
+$progressValueColour: $color__accent;
+$progressBarRadius: 15px;
+
+.progress-bar {
+	background-color: $progressBarColour;
+	border: 2px solid $color__text;
+	border-radius: $progressBarRadius;
+	transform: rotate(-90deg);
+	height: 25px;
+	width: 200px;
+	transform-origin: bottom left;
+	margin-top: 200px;
+}
+
+// Should probably convert this to a mixin.
+.progress-bar::-moz-progress-bar {
+	background: $progressValueColour;
+	border-bottom-left-radius: $progressBarRadius;
+	border-top-left-radius: $progressBarRadius;
+}
+.progress-bar::-webkit-progress-bar {
+	background: $progressBarColour;
+	border-bottom-right-radius: $progressBarRadius;
+	border-top-right-radius: $progressBarRadius;
+}
+.progress-bar::-webkit-progress-value {
+	background: $progressValueColour;
+	border-bottom-left-radius: $progressBarRadius;
+	border-top-left-radius: $progressBarRadius;
+}
+.progress-bar::-ms-fill {
+	background: $progressValueColour;
+	border-bottom-left-radius: $progressBarRadius;
+	border-top-left-radius: $progressBarRadius;
+}
+
+// Fallback for older browsers
+.fallback-progress-bar {
+	margin-top: 0.95em;
+	background-color: $progressBarColour;
+	height: 0.3em;
+}
+
+.fallback-progress-value {
+	background-color: $progressValueColour;
+	display: block;
+	height: 0.3em;
+}
+
+
+.justonetree-treeometer dl {
+	margin: -200px 0 0 $progressBarRadius;
+
+	dd {
+		margin-left: 0;
+	}
+}

--- a/assets/stylesheets/layout/_front-page.scss
+++ b/assets/stylesheets/layout/_front-page.scss
@@ -2,6 +2,7 @@
 @include tablet {
 	.intro {
 		display: flex;
+		justify-content: space-between;
 		margin: 0 5%;
 		max-width: 90%;
 	}

--- a/assets/stylesheets/layout/_front-page.scss
+++ b/assets/stylesheets/layout/_front-page.scss
@@ -1,18 +1,18 @@
-.hero-text {
-	max-width: 350px;
-	position: relative;
-	z-index: 5;
-
-	h2 {
-		//color: $color__highlight;
+// Arrange hero text and tree-o-meter side-by-side on larger screens.
+@include tablet {
+	.intro {
+		display: flex;
+		margin: 0 5%;
+		max-width: 90%;
 	}
+
+	.hero-text {
+		max-width: 400px;
+	}
+
 }
 
-.script {
-	font-family: $font__display;
-	font-size: 126%;
-}
-
+/* Take action section */
 .take-action {
 	display: flex;
 	flex-wrap: wrap;

--- a/assets/stylesheets/layout/_front-page.scss
+++ b/assets/stylesheets/layout/_front-page.scss
@@ -11,6 +11,10 @@
 		max-width: 400px;
 	}
 
+	.justonetree-treeometer {
+		max-width: 400px;
+	}
+
 }
 
 /* Take action section */

--- a/assets/stylesheets/layout/_layout.scss
+++ b/assets/stylesheets/layout/_layout.scss
@@ -21,6 +21,7 @@ body {
 @import "content-sidebar";
 @import "colophon";
 @import "../components/sponsors";
+@import "../components/treeometer";
 
 /*--------------------------------------------------------------
 ## Single Column / No Active Sidebar

--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -31,6 +31,11 @@ h2 {
 	font-size: 1.9rem;
 }
 
+.script {
+	font-family: $font__display;
+	font-size: 126%;
+}
+
 p {
 	margin-bottom: 1.5em;
 }

--- a/functions.php
+++ b/functions.php
@@ -214,3 +214,8 @@ require get_template_directory() . '/inc/svg-icons.php';
  * Load custom post type setup.
  */
 require get_template_directory() . '/inc/cpt/sponsors.php';
+
+/**
+ * Load custom functionality for our tree-o-meter.
+ */
+require get_template_directory() . '/inc/tree-o-meter.php';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -14,8 +14,58 @@ function justonetree_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
+
+	/**
+	 * Add the Theme Options section
+	 */
+	$wp_customize->add_panel( 'justonetree_options_panel', array(
+		'title'          => __( 'Custom Options', 'justonetree' ),
+		'description'    => __( 'Options specific to your theme.', 'justonetree' ),
+	) );
+	// General settings
+	$wp_customize->add_section( 'justonetree_general_settings', array(
+		'title'           => esc_html__( 'Tree-o-meter Settings', 'justonetree' ),
+		'panel'           => 'justonetree_options_panel',
+		'description'     => __( 'Here, you can enter the number of trees currently registered, and the total number of tree registrations aimed for.', 'justonetree' ),
+	) );
+	$wp_customize->add_setting( 'justonetree_trees_registered', array(
+		'type' => 'theme_mod', // or 'option'
+		'capability' => 'edit_theme_options',
+		'default' => '',
+		'transport' => 'refresh', // or postMessage
+		'sanitize_callback' => 'justonetree_sanitize_numeric_value',
+	) );
+	$wp_customize->add_control( 'justonetree_trees_registered', array(
+		'label'   => esc_html__( 'Total number of trees registered', 'justonetree' ),
+		'section'   => 'justonetree_general_settings',
+		'type'    => 'number',
+	) );
+
+	$wp_customize->add_setting( 'justonetree_tree_goal', array(
+		'type' => 'theme_mod', // or 'option'
+		'capability' => 'edit_theme_options',
+		'default' => '',
+		'transport' => 'refresh', // or postMessage
+		'sanitize_callback' => 'justonetree_sanitize_numeric_value',
+	) );
+	$wp_customize->add_control( 'justonetree_tree_goal', array(
+		'label'   => esc_html__( 'Registration goal', 'justonetree' ),
+		'section'   => 'justonetree_general_settings',
+		'type'    => 'number',
+	) );
 }
 add_action( 'customize_register', 'justonetree_customize_register' );
+
+/**
+ * Sanitize a numeric value
+ */
+function justonetree_sanitize_numeric_value( $input ) {
+	if ( is_numeric( $input ) ) :
+		return intval( $input );
+	else:
+		return 0;
+	endif;
+}
 
 /**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -15,18 +15,10 @@ function justonetree_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
 
-	/**
-	 * Add the Theme Options section
-	 */
-	$wp_customize->add_panel( 'justonetree_options_panel', array(
-		'title'          => __( 'Custom Options', 'justonetree' ),
-		'description'    => __( 'Options specific to your theme.', 'justonetree' ),
-	) );
 	// General settings
 	$wp_customize->add_section( 'justonetree_general_settings', array(
-		'title'           => esc_html__( 'Tree-o-meter Settings', 'justonetree' ),
-		'panel'           => 'justonetree_options_panel',
-		'description'     => __( 'Here, you can enter the number of trees currently registered, and the total number of tree registrations aimed for.', 'justonetree' ),
+		'title'           => esc_html__( 'Custom Options', 'justonetree' ),
+		'description'     => __( 'Custom options for your site.', 'justonetree' ),
 	) );
 	$wp_customize->add_setting( 'justonetree_trees_registered', array(
 		'type' => 'theme_mod', // or 'option'

--- a/inc/tree-o-meter.php
+++ b/inc/tree-o-meter.php
@@ -13,6 +13,27 @@ function justonetree_register_shortcodes() {
 }
 add_action( 'init', 'justonetree_register_shortcodes' );
 
+/**
+ * Output the tree-o-meter via a shortcode.
+ */
+function justonetree_treeometer_number( $request ) {
+	$goal = get_theme_mod( 'justonetree_tree_goal' );
+	$registered = get_theme_mod( 'justonetree_trees_registered' );
+
+	$percent = round( ($registered/$goal) * 100 );
+
+	switch( $request ) :
+		case 'goal':
+			return $goal;
+			break;
+		case 'registered':
+			return $registered;
+			break;
+		case 'percent':
+			return $percent;
+			break;
+	endswitch;
+}
 
 /**
  * Output the tree-o-meter via a shortcode.
@@ -20,8 +41,9 @@ add_action( 'init', 'justonetree_register_shortcodes' );
 function justonetree_treeometer_shortcode( $attr, $content = '', $shortcode_tag ) {
 	ob_start(); ?>
 	<div class="justonetree-treeometer">
-		Our Goal: 12,000 Lemon Trees,
-		This Week's Total 1831.
+		<dl>
+			<dt><?php esc_html_e( 'Our Goal:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'goal' ); ?> <?php esc_html_e( 'trees', 'justonetree' ); ?></dt>
+			<dd><?php esc_html_e( 'Current total:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'registered' ); ?> (<?php echo justonetree_treeometer_number( 'percent' ); ?>%)</dd>
 	</div>
 	<?php return ob_get_clean();
 }

--- a/inc/tree-o-meter.php
+++ b/inc/tree-o-meter.php
@@ -47,10 +47,14 @@ function justonetree_treeometer_shortcode( $attr, $content = '', $shortcode_tag 
 			</div>
 		</progress>
 
+		<div id="justonetree-treeometer-text">
+			<h3><?php esc_html_e( 'Current total:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'registered' ); ?> (<?php echo justonetree_treeometer_number( 'percent' ); ?>%)</h3>
 
-		<dl id="justonetree-treeometer-progress">
-			<dt><?php esc_html_e( 'Our Goal:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'goal' ); ?> <?php esc_html_e( 'trees', 'justonetree' ); ?></dt>
-			<dd><?php esc_html_e( 'Current total:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'registered' ); ?> (<?php echo justonetree_treeometer_number( 'percent' ); ?>%)</dd>
+			<p>We need <?php echo justonetree_treeometer_number( 'goal' ); ?> trees! Register yours and be counted.</p>
+
+			<a class="button" href="/register">Register a tree</a>
+		</div>
+
 	</div>
 	<?php return ob_get_clean();
 }

--- a/inc/tree-o-meter.php
+++ b/inc/tree-o-meter.php
@@ -41,7 +41,14 @@ function justonetree_treeometer_number( $request ) {
 function justonetree_treeometer_shortcode( $attr, $content = '', $shortcode_tag ) {
 	ob_start(); ?>
 	<div class="justonetree-treeometer">
-		<dl>
+		<progress max="<?php echo justonetree_treeometer_number( 'goal' ); ?>" value="<?php echo justonetree_treeometer_number( 'registered' ); ?>" class="progress-bar" aria-labelledby="justonetree-treeometer-progress">
+			<div class="fallback-progress-bar" role="presentation">
+				<span class="fallback-progress-value" style="width: <?php echo justonetree_treeometer_number( 'percent' ); ?>%;">&nbsp;</span>
+			</div>
+		</progress>
+
+
+		<dl id="justonetree-treeometer-progress">
 			<dt><?php esc_html_e( 'Our Goal:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'goal' ); ?> <?php esc_html_e( 'trees', 'justonetree' ); ?></dt>
 			<dd><?php esc_html_e( 'Current total:', 'justonetree' ); ?> <?php echo justonetree_treeometer_number( 'registered' ); ?> (<?php echo justonetree_treeometer_number( 'percent' ); ?>%)</dd>
 	</div>

--- a/inc/tree-o-meter.php
+++ b/inc/tree-o-meter.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Custom functionality relating to our tree-o-meter feature.
+ * For now, this just registers a shortcode for use in our pages.
+ *
+ * @package Just_One_Tree
+ */
+/**
+ * Register shortcodes used by theme.
+ */
+function justonetree_register_shortcodes() {
+	add_shortcode( 'treeometer', 'justonetree_treeometer_shortcode' );
+}
+add_action( 'init', 'justonetree_register_shortcodes' );
+
+
+/**
+ * Output the tree-o-meter via a shortcode.
+ */
+function justonetree_treeometer_shortcode( $attr, $content = '', $shortcode_tag ) {
+	ob_start(); ?>
+	<div class="justonetree-treeometer">
+		Our Goal: 12,000 Lemon Trees,
+		This Week's Total 1831.
+	</div>
+	<?php return ob_get_clean();
+}

--- a/style.css
+++ b/style.css
@@ -333,6 +333,10 @@ h1 {
 h2 {
   font-size: 1.9rem; }
 
+.script {
+  font-family: spumante, sans-serif;
+  font-size: 126%; }
+
 p {
   margin-bottom: 1.5em; }
 
@@ -961,15 +965,16 @@ body {
   clear: both;
   margin: 0 0 1.5em; }
 
-.hero-text {
-  max-width: 350px;
-  position: relative;
-  z-index: 5; }
+@media (min-width: 640px) {
+  .intro {
+    display: -ms-flexbox;
+    display: flex;
+    margin: 0 5%;
+    max-width: 90%; }
+  .hero-text {
+    max-width: 400px; } }
 
-.script {
-  font-family: spumante, sans-serif;
-  font-size: 126%; }
-
+/* Take action section */
 .take-action {
   display: -ms-flexbox;
   display: flex;

--- a/style.css
+++ b/style.css
@@ -915,6 +915,15 @@ body {
   .justonetree-sponsor-logos .sponsor {
     margin: 10px; }
 
+.justonetree-treeometer {
+  max-width: 300px; }
+
+progress,
+progress[value] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none; }
+
 .progress-bar {
   background-color: #f9f0cc;
   border: 2px solid #332F25;
@@ -957,10 +966,11 @@ body {
   display: block;
   height: 0.3em; }
 
-.justonetree-treeometer dl {
-  margin: -200px 0 0 15px; }
-  .justonetree-treeometer dl dd {
-    margin-left: 0; }
+#justonetree-treeometer-text {
+  font-size: 0.8em;
+  text-align: center;
+  margin: -200px 0 0 10px;
+  max-width: 230px; }
 
 /*--------------------------------------------------------------
 ## Single Column / No Active Sidebar
@@ -1021,6 +1031,8 @@ body {
     margin: 0 5%;
     max-width: 90%; }
   .hero-text {
+    max-width: 400px; }
+  .justonetree-treeometer {
     max-width: 400px; } }
 
 /* Take action section */

--- a/style.css
+++ b/style.css
@@ -915,6 +915,53 @@ body {
   .justonetree-sponsor-logos .sponsor {
     margin: 10px; }
 
+.progress-bar {
+  background-color: #f9f0cc;
+  border: 2px solid #332F25;
+  border-radius: 15px;
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+  height: 25px;
+  width: 200px;
+  -ms-transform-origin: bottom left;
+  transform-origin: bottom left;
+  margin-top: 200px; }
+
+.progress-bar::-moz-progress-bar {
+  background: #edd672;
+  border-bottom-left-radius: 15px;
+  border-top-left-radius: 15px; }
+
+.progress-bar::-webkit-progress-bar {
+  background: #f9f0cc;
+  border-bottom-right-radius: 15px;
+  border-top-right-radius: 15px; }
+
+.progress-bar::-webkit-progress-value {
+  background: #edd672;
+  border-bottom-left-radius: 15px;
+  border-top-left-radius: 15px; }
+
+.progress-bar::-ms-fill {
+  background: #edd672;
+  border-bottom-left-radius: 15px;
+  border-top-left-radius: 15px; }
+
+.fallback-progress-bar {
+  margin-top: 0.95em;
+  background-color: #f9f0cc;
+  height: 0.3em; }
+
+.fallback-progress-value {
+  background-color: #edd672;
+  display: block;
+  height: 0.3em; }
+
+.justonetree-treeometer dl {
+  margin: -200px 0 0 15px; }
+  .justonetree-treeometer dl dd {
+    margin-left: 0; }
+
 /*--------------------------------------------------------------
 ## Single Column / No Active Sidebar
 --------------------------------------------------------------*/
@@ -969,6 +1016,8 @@ body {
   .intro {
     display: -ms-flexbox;
     display: flex;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
     margin: 0 5%;
     max-width: 90%; }
   .hero-text {


### PR DESCRIPTION
This adds functionality for the initial tree-o-meter as well as basic styling. The numbers (total trees registered and goal number of trees) are user-controllable via a theme option. (We'll be able to nix this for v2, but for now, the numbers will need to be manually entered.)

It's pretty plain right now—looks like this:

<img width="352" alt="screenshot 2016-11-18 17 39 21" src="https://cloud.githubusercontent.com/assets/376315/20440013/28321ad0-adb6-11e6-869f-af8200ecb30b.png">

We can look at giving it an illustrative element in a later revision.

Fixes #2.